### PR TITLE
サーバーの起動をログを追加してわかりやすくした

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,6 @@
+# backend
+
+## project setup
+
+
+### install dependencies

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/dandk105/webapp_study/backend
+
+go 1.21.1

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 )
 
 func main() {
 	http.HandleFunc("/api/greet", greetHandler) // /api/greet へのアクセス時に greetHandler を呼び出す
 
-	http.ListenAndServe(":8080", nil) // 8080ポートでサーバーを起動
+	log.Println("Starting server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil)) // 8080ポートでサーバーを起動. エラーが発生した時のみログに出力
 }
 
 func greetHandler(w http.ResponseWriter, r *http.Request) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -6,8 +6,25 @@ import (
 	"net/http"
 )
 
+// グローバルにハンドラのマップを定義
+var routes = make(map[string]string)
+
+// ルートを追加する関数
+func addRoute(pattern string, description string, handlerFunc http.HandlerFunc) {
+	routes[pattern] = description
+	http.HandleFunc(pattern, handlerFunc)
+}
+
 func main() {
-	http.HandleFunc("/api/greet", greetHandler) // /api/greet へのアクセス時に greetHandler を呼び出す
+
+	// /api/greet へのアクセス時に greetHandler を呼び出す
+	addRoute("/api/greet", "Greet API", greetHandler)
+
+	// サーバー起動時にハンドラの一覧をログに表示
+	log.Println("Registered routes:")
+	for route, desc := range routes {
+		log.Printf("%s: %s\n", route, desc)
+	}
 
 	log.Println("Starting server on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil)) // 8080ポートでサーバーを起動. エラーが発生した時のみログに出力
@@ -26,5 +43,6 @@ func greetHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := fmt.Sprintf("Hello, %s!", name)
+	log.Printf("%s request: %s from %s", r.Method, r.RequestURI, r.RemoteAddr)
 	w.Write([]byte(response))
 }


### PR DESCRIPTION
# 実装した概要

goのバックエンドサーバー起動時に、ログが出力されておらず起動しているのか分からない状態を修正
goのバックエンドサーバー起動時に、受け付けているサーバーのハンドラー一覧を表示するように修正

### 教えて！
今回の内容だとrouterはあくまで説明のためのマッピングを行っているだけで、実際にrest apiの登録を行うのは、
http.HadleFunc()関数という点に注意

```golang
routes = [string]string{
"/api/greet": "Greet API"
}

```

### 関連するIssue
次は、dbにユーザーの名前を登録して、APIからユーザーの名前を取得できるようにする
