### PR TITLE
improve github actions of gh pages

### DIFF
--- a/.github/workflows/build-gh-pages-made-from-jekyll.yml
+++ b/.github/workflows/build-gh-pages-made-from-jekyll.yml
@@ -1,5 +1,4 @@
-# Deploy Jekyll with Github Pages
-name: Deploy Jekyll with GitHub Pages
+name: Build Github Pages from Jekyll
 
 on:
   # Runs on pushes targeting the default branch
@@ -57,16 +56,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
+          # nameを指定しないと、デプロイ時にエラーが発生する為、指定している
+          # 対象workflow: deploy-gh-pages-made-from-jekyll.yml
+          name: gh-pages-with-jekyll
           path: ${{ github.workspace }}/pages/_site
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v3

--- a/.github/workflows/deploy-gh-pages-mada-from-jekyll.yml
+++ b/.github/workflows/deploy-gh-pages-mada-from-jekyll.yml
@@ -1,0 +1,39 @@
+name: Deploy GitHub Pages with Jekyll
+
+on:
+  # 手動実行のみ有効とする理由としては、biludが成功した時点で、デプロイするためのartifactが作成されるため
+  # そのartifactをデプロイするのは、ビルドができている時のみでかつ連続してデプロイしたい時に、いちいちメインブランチにpushするのは
+  # 変更の適応を柔軟に試せないため
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          # nameをbuildのnameに合わせなければ、artifactが見つからず実行されないので注意
+          # 対象workflow: build-gh-pages-made-from-jekyll.yml
+          name: gh-pages-with-jekyll
+          path: ${{ github.workspace }}/pages/_site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/golang-format-and-lint.yml
+++ b/.github/workflows/golang-format-and-lint.yml
@@ -2,8 +2,8 @@ name: Golang lint and format
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: ["main"]
+    paths: ['backend/**']
 
 concurrency:
   group: "golang"


### PR DESCRIPTION
github pagesの作成をより、楽に確かめるかつ、デプロイできる様に
gh pages用のデプロイCI/CDをページで分割した

golang formatを毎回動かすのではなく、backendフォルダに変更があった時のみに作動する様に改善した